### PR TITLE
Git clone now fetches only HEAD^ history and has a timeout

### DIFF
--- a/bin/repolinter.js
+++ b/bin/repolinter.js
@@ -75,11 +75,11 @@ require('yargs')
         tmpDir = await fs.promises.mkdtemp(
           path.join(os.tmpdir(), 'repolinter-')
         )
-        const result = await git.clone(argv.directory, tmpDir)
+        const result = await git.clone(argv.directory, tmpDir, { '--depth': '2' })
         if (result) {
           console.error(result)
           process.exitCode = 1
-          rimraf(tmpDir, () => {})
+          rimraf(tmpDir, () => { })
           return
         }
       }
@@ -110,7 +110,7 @@ require('yargs')
       process.exitCode = output.passed ? 0 : 1
       // delete the tmpdir if it exists
       if (tmpDir) {
-        rimraf(tmpDir, function () {})
+        rimraf(tmpDir, function () { })
       }
     }
   )

--- a/bin/repolinter.js
+++ b/bin/repolinter.js
@@ -80,7 +80,7 @@ require('yargs')
             console.log(`git.${method} ${stage} stage ${progress}% complete`)
           },
           timeout: {
-            block: 300000 // 5 minutes
+            block: 1000 // 1 second
           }
         }).clone(argv.directory, tmpDir, { '--depth': '2' })
         if (result) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "repolinter",
       "version": "0.11.2",
       "license": "Apache-2.0",
       "dependencies": {
@@ -27,7 +28,7 @@
         "nock": "^13.0.5",
         "node-fetch": "^2.6.0",
         "rimraf": "^3.0.2",
-        "simple-git": "^2.25.0",
+        "simple-git": "^3.3.0",
         "yargs": "^15.4.1"
       },
       "bin": {
@@ -5100,10 +5101,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -7333,20 +7333,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -10231,15 +10217,6 @@
         "url": "https://opencollective.com/mochajs"
       }
     },
-    "node_modules/mocha/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/mocha/node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -10269,12 +10246,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
-    },
-    "node_modules/mocha/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
     },
     "node_modules/mocha/node_modules/debug": {
       "version": "4.2.0",
@@ -10456,9 +10427,6 @@
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       },
       "engines": {
         "node": ">=6"
@@ -12455,35 +12423,18 @@
       "dev": true
     },
     "node_modules/simple-git": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.25.0.tgz",
-      "integrity": "sha512-RMBFWKiPDl3rAoFbEaCVsjQ0v6sgR0q7cyUF9e/4lR81Mf2/5xwop0aCQatUDXKMIXnkuOG6aTEadQmGtOw4mg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.3.0.tgz",
+      "integrity": "sha512-K9qcbbZwPHhk7MLi0k0ekvSFXJIrRoXgHhqMXAFM75qS68vdHTcuzmul1ilKI02F/4lXshVgBoDll2t++JK0PQ==",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.1"
-      }
-    },
-    "node_modules/simple-git/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dependencies": {
-        "ms": "2.1.2"
+        "debug": "^4.3.3"
       },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/steveukx/"
       }
-    },
-    "node_modules/simple-git/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/slice-ansi": {
       "version": "2.1.0",
@@ -18013,6 +17964,12 @@
             "to-regex-range": "^5.0.1"
           }
         },
+        "fsevents": {
+          "version": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
+        },
         "is-number": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -18989,9 +18946,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -20745,13 +20702,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -22982,6 +22932,14 @@
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -22999,10 +22957,9 @@
             "wrap-ansi": "^7.0.0"
           }
         },
-        "diff": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "dev": true
         },
         "emoji-regex": {
@@ -24690,13 +24647,13 @@
       "dev": true
     },
     "simple-git": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.25.0.tgz",
-      "integrity": "sha512-RMBFWKiPDl3rAoFbEaCVsjQ0v6sgR0q7cyUF9e/4lR81Mf2/5xwop0aCQatUDXKMIXnkuOG6aTEadQmGtOw4mg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.3.0.tgz",
+      "integrity": "sha512-K9qcbbZwPHhk7MLi0k0ekvSFXJIrRoXgHhqMXAFM75qS68vdHTcuzmul1ilKI02F/4lXshVgBoDll2t++JK0PQ==",
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.1"
+        "debug": "^4.3.3"
       }
     },
     "slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "nock": "^13.0.5",
     "node-fetch": "^2.6.0",
     "rimraf": "^3.0.2",
-    "simple-git": "^2.25.0",
+    "simple-git": "^3.3.0",
     "yargs": "^15.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Motivation

On large repositories, the process often got stuck and failed for some reason. This was difficult to diagnose due to lack of logging.

## Proposed Changes

Only checkout the HEAD^ instead of the whole repository, with the entire history, including all of its branches and their history. 
Include more logging as well as a time out of 1 second if the process is finished but stuck closing. This timeout is only triggered when the Git process has been stuck for 1 second.

## Test Plan

Test with ``bin/repolinter.js -g https://github.com/microsoft/vscode``  and see the progress being reported like:
```git.clone resolving stage 90% complete
git.clone resolving stage 91% complete
git.clone resolving stage 92% complete
git.clone resolving stage 93% complete
git.clone resolving stage 94% complete
git.clone resolving stage 95% complete
git.clone resolving stage 96% complete
git.clone resolving stage 97% complete
git.clone resolving stage 98% complete
git.clone resolving stage 99% complete
git.clone resolving stage 100% complete
git.clone resolving stage 100% complete
```


Signed-off-by: Brend Smits <brend.smits@philips.com>
