### PR TITLE
fix: update git local config to fetch remote branches

### DIFF
--- a/rules/any-file-contents.js
+++ b/rules/any-file-contents.js
@@ -14,8 +14,8 @@ const fileContents = require('./file-contents')
  * @param {object} options The rule configuration
  * @returns {Promise<Result>} The lint rule result
  */
-function anyFileContents(fs, options) {
-  return fileContents(fs, options, false, true)
+function anyFileContents(fs, options, git) {
+  return fileContents(fs, options, false, true, git)
 }
 
 module.exports = anyFileContents

--- a/rules/best-practices-badge-present.js
+++ b/rules/best-practices-badge-present.js
@@ -7,15 +7,21 @@ const fileContents = require('./file-contents')
 const bestPracticesRegExp =
   'https://bestpractices\\.coreinfrastructure\\.org(/\\w+)?/projects/\\d+'
 
-module.exports = async function (fileSystem, options = {}) {
-  const readmeContainsBadge = await fileContents(fileSystem, {
-    globsAll: ['README*'],
-    content: bestPracticesRegExp,
-    nocase: true,
-    flags: 'i',
-    'fail-on-non-existent': true,
-    'human-readable-content': 'Best Practices Badge'
-  })
+module.exports = async function (fileSystem, options = {}, git) {
+  const readmeContainsBadge = await fileContents(
+    fileSystem,
+    {
+      globsAll: ['README*'],
+      content: bestPracticesRegExp,
+      nocase: true,
+      flags: 'i',
+      'fail-on-non-existent': true,
+      'human-readable-content': 'Best Practices Badge'
+    },
+    undefined,
+    undefined,
+    git
+  )
   if (!readmeContainsBadge.passed || !options.minPercentage) {
     return readmeContainsBadge
   }

--- a/rules/file-contents.js
+++ b/rules/file-contents.js
@@ -20,21 +20,26 @@ function getContent(options) {
  * @param {object} options The rule configuration
  * @param {boolean} not Whether or not to invert the result (not contents instead of contents)
  * @param {boolean} any Whether to check if the regular expression is contained by at least one of the files in the list
+ * @param {SimpleGit} git A simple-git object configured correct path
  * @returns {Promise<Result>} The lint rule result
  */
-async function fileContents(fs, options, not = false, any = false) {
+async function fileContents(fs, options, not = false, any = false, git) {
   // support legacy configuration keys
   const fileList = (any ? options.globsAny : options.globsAll) || options.files
-  const git = simpleGit({
-    progress({ method, stage, progress }) {
-      console.log(`git.${method} ${stage} stage ${progress}% complete`)
-    },
-    baseDir: fs.targetDir
-  })
+
+  if (git === undefined) {
+    git = simpleGit({
+      progress({ method, stage, progress }) {
+        console.log(`git.${method} ${stage} stage ${progress}% complete`)
+      },
+      baseDir: fs.targetDir
+    })
+  }
+
   const defaultBranch = (await git.branchLocal()).current
   const branches = options.branches || [defaultBranch]
   const defaultRemote = (await git.getRemotes())[0]
-  await fetchAllBranchesRemote(git, defaultRemote.name).catch(err => err)
+  await fetchAllBranchesRemote(git, defaultRemote.name)
 
   let results = []
   let noMatchingFileFoundCount = 0

--- a/rules/file-contents.js
+++ b/rules/file-contents.js
@@ -25,9 +25,16 @@ function getContent(options) {
 async function fileContents(fs, options, not = false, any = false) {
   // support legacy configuration keys
   const fileList = (any ? options.globsAny : options.globsAll) || options.files
-  const defaultBranch = (await simpleGit().branchLocal()).current
+  const git = simpleGit({
+    progress({ method, stage, progress }) {
+      console.log(`git.${method} ${stage} stage ${progress}% complete`)
+    },
+    baseDir: fs.targetDir
+  })
+  const defaultBranch = (await git.branchLocal()).current
   const branches = options.branches || [defaultBranch]
-  const defaultRemote = (await simpleGit().getRemotes())[0]
+  const defaultRemote = (await git.getRemotes())[0]
+  await fetchAllBranchesRemote(git, defaultRemote.name).catch(err => err)
 
   let results = []
   let noMatchingFileFoundCount = 0
@@ -35,8 +42,8 @@ async function fileContents(fs, options, not = false, any = false) {
   for (let index = 0; index < branches.length; index++) {
     const branch = branches[index]
     if (
-      !(await doesBranchExist(branch)) &&
-      !(await doesBranchExist(`${defaultRemote.name}/${branch}`))
+      !(await doesBranchExist(git, branch)) &&
+      !(await doesBranchExist(git, `${defaultRemote.name}/${branch}`))
     ) {
       noMatchingFileFoundCount++
       continue
@@ -44,10 +51,9 @@ async function fileContents(fs, options, not = false, any = false) {
     // if branch name is the default branch from clone, ignore and do not checkout.
     if (branch !== defaultBranch) {
       // perform git checkout of the target branch
-      await gitCheckout(branch, defaultRemote)
+      await gitCheckout(git, branch, defaultRemote.name)
       switchedBranch = true
     }
-
     const files = await fs.findAllFiles(fileList, !!options.nocase)
     if (files.length === 0) {
       noMatchingFileFoundCount++
@@ -76,7 +82,7 @@ async function fileContents(fs, options, not = false, any = false) {
   }
   if (switchedBranch) {
     // Make sure we are back using the default branch
-    await gitCheckout(defaultBranch, defaultRemote)
+    await gitCheckout(git, defaultBranch, defaultRemote.name)
   }
 
   if (noMatchingFileFoundCount === branches.length) {
@@ -97,34 +103,36 @@ async function fileContents(fs, options, not = false, any = false) {
   return new Result('', filteredRuleOutcomes, passed)
 }
 
+// Fetch all remote branches, fetches just the names on remote.
+// Needs to be done since we did a shallow checkout
+async function fetchAllBranchesRemote(git, defaultRemote) {
+  // Since we do a shallow clone, we need to first retrieve the branches
+  await git.addConfig(
+    `remote.${defaultRemote}.fetch`,
+    `+refs/heads/*:refs/remotes/${defaultRemote}/*`
+  )
+  await git.remote(['update'])
+}
+
 // Check if branch exists
-async function doesBranchExist(branch) {
-  const branches = (await simpleGit().branch(['-r'])).all
+async function doesBranchExist(git, branch) {
+  const branches = (await git.branch(['-r'])).all
   if (branches.find(v => v === branch)) {
     return true
   }
   return false
 }
 // Helper method to quickly checkout to a different branch
-async function gitCheckout(branch, defaultRemote) {
-  const checkoutResult = await simpleGit({
-    progress({ method, stage, progress }) {
-      console.log(`git.${method} ${stage} stage ${progress}% complete`)
-    }
-  }).checkout(branch)
-
+async function gitCheckout(git, branch, defaultRemote) {
+  const checkoutResult = await git.checkout(branch)
   if (checkoutResult) {
-    const checkoutResultWithDefaultOrigin = await simpleGit({
-      progress({ method, stage, progress }) {
-        console.log(`git.${method} ${stage} stage ${progress}% complete`)
-      }
-    }).checkout(`${defaultRemote.name}/${branch}`)
+    const checkoutResultWithDefaultOrigin = await git.checkout(
+      `${defaultRemote}/${branch}`
+    )
     if (checkoutResultWithDefaultOrigin) {
       console.error(checkoutResult)
       process.exitCode = 1
-      throw new Error(
-        `Failed checking out branch: ${defaultRemote.name}/${branch}`
-      )
+      throw new Error(`Failed checking out branch: ${defaultRemote}/${branch}`)
     }
   }
 }

--- a/rules/file-not-contents.js
+++ b/rules/file-not-contents.js
@@ -14,8 +14,8 @@ const fileContents = require('./file-contents')
  * @param {object} options The rule configuration
  * @returns {Promise<Result>} The lint rule result
  */
-function fileNotContents(fs, options) {
-  return fileContents(fs, options, true)
+function fileNotContents(fs, options, git) {
+  return fileContents(fs, options, true, undefined, git)
 }
 
 module.exports = fileNotContents

--- a/tests/formatters/markdown_formatter_tests.js
+++ b/tests/formatters/markdown_formatter_tests.js
@@ -95,7 +95,6 @@ describe('formatters', () => {
 
     it('generates valid markdown when running against itself', async function () {
       this.timeout(30000)
-
       const lintres = await repolinter.lint(path.resolve('.'))
 
       const actual = formatter.formatOutput(lintres, false)

--- a/tests/rules/any_file_contents_tests.js
+++ b/tests/rules/any_file_contents_tests.js
@@ -8,6 +8,26 @@ const FileSystem = require('../../lib/file_system')
 describe('rule', () => {
   describe('any_file_contents', () => {
     const anyFileContents = require('../../rules/any-file-contents')
+    const mockGit = {
+      branchLocal() {
+        return { current: 'master' }
+      },
+      getRemotes() {
+        return [{ name: 'origin' }]
+      },
+      addConfig() {
+        return Promise.resolve
+      },
+      remote() {
+        return Promise.resolve
+      },
+      branch() {
+        return { all: ['master'] }
+      },
+      checkout() {
+        return Promise.resolve
+      }
+    }
 
     it('returns passes if requested file contents exists in exactly one file', async () => {
       /** @type {any} */
@@ -25,7 +45,7 @@ describe('rule', () => {
         content: '[abcdef][oO0][^q]'
       }
 
-      const actual = await anyFileContents(mockfs, ruleopts)
+      const actual = await anyFileContents(mockfs, ruleopts, mockGit)
       expect(actual.passed).to.equal(true)
       expect(actual.targets).to.have.length(3)
       expect(actual.targets[2]).to.deep.include({
@@ -50,7 +70,7 @@ describe('rule', () => {
         content: '[abcdef][oO0][^q]'
       }
 
-      const actual = await anyFileContents(mockfs, ruleopts)
+      const actual = await anyFileContents(mockfs, ruleopts, mockGit)
 
       expect(actual.passed).to.equal(true)
       expect(actual.targets).to.have.length(3)
@@ -84,7 +104,7 @@ describe('rule', () => {
         content: '[abcdef][oO0][^q]'
       }
 
-      const actual = await anyFileContents(mockfs, ruleopts)
+      const actual = await anyFileContents(mockfs, ruleopts, mockGit)
       expect(actual.passed).to.equal(false)
       expect(actual.targets).to.have.length(3)
       expect(actual.targets[0]).to.deep.include({
@@ -113,7 +133,7 @@ describe('rule', () => {
         'fail-on-non-existent': true
       }
 
-      const actual = await anyFileContents(mockfs, ruleopts)
+      const actual = await anyFileContents(mockfs, ruleopts, mockGit)
 
       expect(actual.passed).to.equal(false)
     })
@@ -130,7 +150,7 @@ describe('rule', () => {
         patterns: ['something'],
         'fail-on-non-existent': true
       }
-      const actual = await anyFileContents(fs, ruleopts)
+      const actual = await anyFileContents(fs, ruleopts, mockGit)
       expect(actual.passed).to.equal(false)
     })
   })

--- a/tests/rules/best_practices_badge_tests.js
+++ b/tests/rules/best_practices_badge_tests.js
@@ -8,6 +8,26 @@ const expect = chai.expect
 describe('rule', () => {
   describe('Best Practices Badge', () => {
     const BestpracticesBadgePresent = require('../../rules/best-practices-badge-present')
+    const mockGit = {
+      branchLocal() {
+        return { current: 'master' }
+      },
+      getRemotes() {
+        return [{ name: 'origin' }]
+      },
+      addConfig() {
+        return Promise.resolve
+      },
+      remote() {
+        return Promise.resolve
+      },
+      branch() {
+        return { all: ['master'] }
+      },
+      checkout() {
+        return Promise.resolve
+      }
+    }
 
     it('fails if readme is missing', async () => {
       const mockfs = {
@@ -16,7 +36,7 @@ describe('rule', () => {
         targetDir: '.'
       }
 
-      const actual = await BestpracticesBadgePresent(mockfs)
+      const actual = await BestpracticesBadgePresent(mockfs, undefined, mockGit)
       expect(actual.passed).to.equal(false)
       expect(actual.message).to.include('not find')
     })
@@ -28,7 +48,7 @@ describe('rule', () => {
         targetDir: '.'
       }
 
-      const actual = await BestpracticesBadgePresent(mockfs)
+      const actual = await BestpracticesBadgePresent(mockfs, undefined, mockGit)
       expect(actual.passed).to.equal(false)
       expect(actual.targets.length).to.equal(1)
       expect(actual.targets[0].message).to.equal(
@@ -44,7 +64,7 @@ describe('rule', () => {
         targetDir: '.'
       }
 
-      const actual = await BestpracticesBadgePresent(mockfs)
+      const actual = await BestpracticesBadgePresent(mockfs, undefined, mockGit)
       expect(actual.passed).to.equal(true)
     })
 
@@ -56,7 +76,7 @@ describe('rule', () => {
         targetDir: '.'
       }
 
-      const actual = await BestpracticesBadgePresent(mockfs)
+      const actual = await BestpracticesBadgePresent(mockfs, undefined, mockGit)
       expect(actual.passed).to.equal(true)
     })
 
@@ -68,7 +88,7 @@ describe('rule', () => {
         targetDir: '.'
       }
 
-      const actual = await BestpracticesBadgePresent(mockfs)
+      const actual = await BestpracticesBadgePresent(mockfs, undefined, mockGit)
       expect(actual.passed).to.equal(false)
     })
     describe('minPercentage', () => {
@@ -80,16 +100,24 @@ describe('rule', () => {
       }
 
       it('passes when minPercentage is not set', async () => {
-        const actual = await BestpracticesBadgePresent(mockfs, {
-          minPercentage: null
-        })
+        const actual = await BestpracticesBadgePresent(
+          mockfs,
+          {
+            minPercentage: null
+          },
+          mockGit
+        )
         expect(actual.passed).to.equal(true)
       })
 
       it('passes when minPercentage is set to 0', async () => {
-        const actual = await BestpracticesBadgePresent(mockfs, {
-          minPercentage: 0
-        })
+        const actual = await BestpracticesBadgePresent(
+          mockfs,
+          {
+            minPercentage: 0
+          },
+          mockGit
+        )
         expect(actual.passed).to.equal(true)
       })
 
@@ -98,9 +126,13 @@ describe('rule', () => {
           .get('/projects/100.json')
           .reply(200, { tiered_percentage: 99 })
 
-        const actual = await BestpracticesBadgePresent(mockfs, {
-          minPercentage: 100
-        })
+        const actual = await BestpracticesBadgePresent(
+          mockfs,
+          {
+            minPercentage: 100
+          },
+          mockGit
+        )
         expect(actual.passed).to.equal(false)
         scope.done()
       })
@@ -110,9 +142,13 @@ describe('rule', () => {
           .get('/projects/100.json')
           .reply(404)
 
-        const actual = await BestpracticesBadgePresent(mockfs, {
-          minPercentage: 100
-        })
+        const actual = await BestpracticesBadgePresent(
+          mockfs,
+          {
+            minPercentage: 100
+          },
+          mockGit
+        )
         expect(actual.passed).to.equal(false)
         scope.done()
       })
@@ -122,9 +158,13 @@ describe('rule', () => {
           .get('/projects/100.json')
           .reply(200, { tiered_percentage: 100 })
 
-        const actual = await BestpracticesBadgePresent(mockfs, {
-          minPercentage: 100
-        })
+        const actual = await BestpracticesBadgePresent(
+          mockfs,
+          {
+            minPercentage: 100
+          },
+          mockGit
+        )
         expect(actual.passed).to.equal(true)
         scope.done()
       })

--- a/tests/rules/file_contents_tests.js
+++ b/tests/rules/file_contents_tests.js
@@ -8,7 +8,26 @@ const FileSystem = require('../../lib/file_system')
 describe('rule', () => {
   describe('files_contents', () => {
     const fileContents = require('../../rules/file-contents')
-
+    const mockGit = {
+      branchLocal() {
+        return { current: 'master' }
+      },
+      getRemotes() {
+        return [{ name: 'origin' }]
+      },
+      addConfig() {
+        return Promise.resolve
+      },
+      remote() {
+        return Promise.resolve
+      },
+      branch() {
+        return { all: ['master'] }
+      },
+      checkout() {
+        return Promise.resolve
+      }
+    }
     it('returns passes if requested file contents exists', async () => {
       /** @type {any} */
       const mockfs = {
@@ -26,7 +45,13 @@ describe('rule', () => {
         content: 'foo'
       }
 
-      const actual = await fileContents(mockfs, ruleopts)
+      const actual = await fileContents(
+        mockfs,
+        ruleopts,
+        undefined,
+        undefined,
+        mockGit
+      )
       expect(actual.passed).to.equal(true)
       expect(actual.targets).to.have.length(1)
       expect(actual.targets[0]).to.deep.include({
@@ -52,7 +77,13 @@ describe('rule', () => {
         'human-readable-content': 'actually foo'
       }
 
-      const actual = await fileContents(mockfs, ruleopts)
+      const actual = await fileContents(
+        mockfs,
+        ruleopts,
+        undefined,
+        undefined,
+        mockGit
+      )
       expect(actual.passed).to.equal(true)
       expect(actual.targets).to.have.length(1)
       expect(actual.targets[0]).to.deep.include({
@@ -81,7 +112,13 @@ describe('rule', () => {
         content: 'bar'
       }
 
-      const actual = await fileContents(mockfs, ruleopts)
+      const actual = await fileContents(
+        mockfs,
+        ruleopts,
+        undefined,
+        undefined,
+        mockGit
+      )
 
       expect(actual.passed).to.equal(false)
       expect(actual.targets).to.have.length(1)
@@ -106,7 +143,13 @@ describe('rule', () => {
         content: 'foo'
       }
 
-      const actual = await fileContents(mockfs, ruleopts)
+      const actual = await fileContents(
+        mockfs,
+        ruleopts,
+        undefined,
+        undefined,
+        mockGit
+      )
       expect(actual.passed).to.equal(true)
       expect(actual.targets).to.have.length(1)
       expect(actual.targets[0].passed).to.equal(false)
@@ -128,7 +171,13 @@ describe('rule', () => {
         'fail-on-non-existent': true
       }
 
-      const actual = await fileContents(mockfs, ruleopts)
+      const actual = await fileContents(
+        mockfs,
+        ruleopts,
+        undefined,
+        undefined,
+        mockGit
+      )
 
       expect(actual.passed).to.equal(false)
     })
@@ -144,7 +193,7 @@ describe('rule', () => {
         lineCount: 1,
         patterns: ['something']
       }
-      const actual = await fileContents(fs, rule)
+      const actual = await fileContents(fs, rule, undefined, undefined, mockGit)
 
       expect(actual.passed).to.equal(true)
     })

--- a/tests/rules/file_hash_tests.js
+++ b/tests/rules/file_hash_tests.js
@@ -7,7 +7,26 @@ const expect = chai.expect
 describe('rule', () => {
   describe('files_hash', () => {
     const fileContents = require('../../rules/file-hash')
-
+    const mockGit = {
+      branchLocal() {
+        return { current: 'master' }
+      },
+      getRemotes() {
+        return [{ name: 'origin' }]
+      },
+      addConfig() {
+        return Promise.resolve
+      },
+      remote() {
+        return Promise.resolve
+      },
+      branch() {
+        return { all: ['master'] }
+      },
+      checkout() {
+        return Promise.resolve
+      }
+    }
     it('returns passes if requested file matches the hash', async () => {
       /** @type {any} */
       const mockfs = {
@@ -25,7 +44,13 @@ describe('rule', () => {
         hash: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae'
       }
 
-      const actual = await fileContents(mockfs, ruleopts)
+      const actual = await fileContents(
+        mockfs,
+        ruleopts,
+        undefined,
+        undefined,
+        mockGit
+      )
       expect(actual.passed).to.equal(true)
       expect(actual.targets).to.have.length(1)
       expect(actual.targets[0]).to.deep.include({
@@ -53,7 +78,13 @@ describe('rule', () => {
         nocase: true
       }
 
-      const actual = await fileContents(mockfs, ruleopts)
+      const actual = await fileContents(
+        mockfs,
+        ruleopts,
+        undefined,
+        undefined,
+        mockGit
+      )
       expect(actual.passed).to.equal(true)
       expect(actual.targets).to.have.length(1)
       expect(actual.targets[0]).to.deep.include({
@@ -81,7 +112,13 @@ describe('rule', () => {
           'f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7'
       }
 
-      const actual = await fileContents(mockfs, ruleopts)
+      const actual = await fileContents(
+        mockfs,
+        ruleopts,
+        undefined,
+        undefined,
+        mockGit
+      )
       expect(actual.passed).to.equal(true)
       expect(actual.targets).to.have.length(1)
       expect(actual.targets[0]).to.deep.include({
@@ -107,7 +144,13 @@ describe('rule', () => {
         hash: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
       }
 
-      const actual = await fileContents(mockfs, ruleopts)
+      const actual = await fileContents(
+        mockfs,
+        ruleopts,
+        undefined,
+        undefined,
+        mockGit
+      )
       expect(actual.passed).to.equal(false)
       expect(actual.targets).to.have.length(1)
       expect(actual.targets[0]).to.deep.include({
@@ -131,7 +174,13 @@ describe('rule', () => {
         content: 'foo'
       }
 
-      const actual = await fileContents(mockfs, ruleopts)
+      const actual = await fileContents(
+        mockfs,
+        ruleopts,
+        undefined,
+        undefined,
+        mockGit
+      )
       expect(actual.passed).to.equal(false)
     })
 
@@ -151,7 +200,13 @@ describe('rule', () => {
         'succeed-on-non-existent': true
       }
 
-      const actual = await fileContents(mockfs, ruleopts)
+      const actual = await fileContents(
+        mockfs,
+        ruleopts,
+        undefined,
+        undefined,
+        mockGit
+      )
 
       expect(actual.passed).to.equal(true)
     })
@@ -173,7 +228,13 @@ describe('rule', () => {
         hash: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae'
       }
 
-      const actual = await fileContents(mockfs, ruleopts)
+      const actual = await fileContents(
+        mockfs,
+        ruleopts,
+        undefined,
+        undefined,
+        mockGit
+      )
       expect(actual.passed).to.equal(true)
       expect(actual.targets).to.have.length(1)
       expect(actual.targets[0]).to.deep.include({

--- a/tests/rules/file_not_contents_tests.js
+++ b/tests/rules/file_not_contents_tests.js
@@ -8,6 +8,26 @@ const FileSystem = require('../../lib/file_system')
 describe('rule', () => {
   describe('files_not_contents', () => {
     const fileNotContents = require('../../rules/file-not-contents')
+    const mockGit = {
+      branchLocal() {
+        return { current: 'master' }
+      },
+      getRemotes() {
+        return [{ name: 'origin' }]
+      },
+      addConfig() {
+        return Promise.resolve
+      },
+      remote() {
+        return Promise.resolve
+      },
+      branch() {
+        return { all: ['master'] }
+      },
+      checkout() {
+        return Promise.resolve
+      }
+    }
 
     it('returns passes if requested file contents do not exist', async () => {
       /** @type {any} */
@@ -26,7 +46,7 @@ describe('rule', () => {
         content: 'bar'
       }
 
-      const actual = await fileNotContents(mockfs, ruleopts)
+      const actual = await fileNotContents(mockfs, ruleopts, mockGit)
       expect(actual.passed).to.equal(true)
       expect(actual.targets).to.have.length(1)
       expect(actual.targets[0]).to.deep.include({
@@ -53,7 +73,7 @@ describe('rule', () => {
         content: 'foo'
       }
 
-      const actual = await fileNotContents(mockfs, ruleopts)
+      const actual = await fileNotContents(mockfs, ruleopts, mockGit)
       expect(actual.passed).to.equal(false)
       expect(actual.targets).to.have.length(1)
       expect(actual.targets[0]).to.deep.include({
@@ -79,7 +99,7 @@ describe('rule', () => {
         'succeed-on-non-existent': true
       }
 
-      const actual = await fileNotContents(mockfs, ruleopts)
+      const actual = await fileNotContents(mockfs, ruleopts, mockGit)
 
       expect(actual.passed).to.equal(true)
       expect(actual.targets).to.have.length(1)
@@ -101,7 +121,7 @@ describe('rule', () => {
         content: 'foo'
       }
 
-      const actual = await fileNotContents(mockfs, ruleopts)
+      const actual = await fileNotContents(mockfs, ruleopts, mockGit)
       expect(actual.passed).to.equal(true)
       expect(actual.targets).to.have.length(1)
       expect(actual.targets[0].pattern).to.equal(ruleopts.globsAll[0])
@@ -118,7 +138,7 @@ describe('rule', () => {
         lineCount: 1,
         patterns: ['something']
       }
-      const actual = await fileNotContents(fs, ruleopts)
+      const actual = await fileNotContents(fs, ruleopts, mockGit)
       expect(actual.passed).to.equal(true)
     })
   })

--- a/tests/rules/json_schema_passes_test.js
+++ b/tests/rules/json_schema_passes_test.js
@@ -8,7 +8,6 @@ const expect = chai.expect
 describe('rule', () => {
   describe('json_schema_passes', () => {
     const jsonSchemaPasses = require('../../rules/json-schema-passes')
-
     it('returns passes if requested file matches the schema', async () => {
       /** @type {any} */
       const mockfs = {


### PR DESCRIPTION
Shallow clone does not include remote branches or any of such information.
We need to update the local git config for it to update and be able to retrieve the remote branches it needs.