### PR TITLE
fix: Fix issue when no valid assignee is found, fix would not execute

### DIFF
--- a/fixes/github-issue-create.js
+++ b/fixes/github-issue-create.js
@@ -74,7 +74,10 @@ async function createGithubIssue(fs, options, targets, dryRun = false) {
           error.message.indexOf('"field":"assignees","code":"invalid"}')
         ) {
           issuesAssignees = []
-          if (assigneeSelectCount <= assignees.data.length) {
+          if (
+            assigneeSelectCount <= assignees.data.length &&
+            assigneeSelectCount <= 6
+          ) {
             assigneeSelectCount++
             issuesAssignees.push(assignees.data[assigneeSelectCount].login)
           }
@@ -122,7 +125,10 @@ async function createGithubIssue(fs, options, targets, dryRun = false) {
                 error.message.indexOf('"field":"assignees","code":"invalid"}')
               ) {
                 issuesAssignees = []
-                if (assigneeSelectCount <= assignees.data.length) {
+                if (
+                  assigneeSelectCount <= assignees.data.length &&
+                  assigneeSelectCount <= 6
+                ) {
                   assigneeSelectCount++
                   issuesAssignees.push(
                     assignees.data[assigneeSelectCount].login
@@ -169,7 +175,10 @@ async function createGithubIssue(fs, options, targets, dryRun = false) {
               error.message.indexOf('"field":"assignees","code":"invalid"}')
             ) {
               issuesAssignees = []
-              if (assigneeSelectCount <= assignees.data.length) {
+              if (
+                assigneeSelectCount <= assignees.data.length &&
+                assigneeSelectCount <= 6
+              ) {
                 assigneeSelectCount++
                 issuesAssignees.push(assignees.data[assigneeSelectCount].login)
               }
@@ -204,7 +213,10 @@ async function createGithubIssue(fs, options, targets, dryRun = false) {
         error.message.indexOf('"field":"assignees","code":"invalid"}')
       ) {
         issuesAssignees = []
-        if (assigneeSelectCount <= assignees.data.length) {
+        if (
+          assigneeSelectCount <= assignees.data.length &&
+          assigneeSelectCount <= 6
+        ) {
           assigneeSelectCount++
           issuesAssignees.push(assignees.data[assigneeSelectCount].login)
         }

--- a/fixes/github-issue-create.js
+++ b/fixes/github-issue-create.js
@@ -47,18 +47,18 @@ async function createGithubIssue(fs, options, targets, dryRun = false) {
       this.Octokit
     )
 
-    let Contributors = []
+    let contributors = []
     // Retrieve committers of a repository if assignTopCommitter option is set or undefined.
     if (options.assignTopCommitter === undefined) {
       options.assignTopCommitter = true
     }
     if (options.assignTopCommitter) {
-      Contributors = await getTopCommittersOfRepository(
+      contributors = await getTopCommittersOfRepository(
         targetOrg,
         targetRepository
       )
-      if (Contributors !== undefined && Contributors.data.length > 0) {
-        issueAssignees.push(Contributors.data[0].login)
+      if (contributors !== undefined && contributors.data.length > 0) {
+        issueAssignees.push(contributors.data[0].login)
       }
     }
 
@@ -67,7 +67,7 @@ async function createGithubIssue(fs, options, targets, dryRun = false) {
     if (issues === null || issues === undefined) {
       try {
         // Issue should include the broken rule, a message in the body and a label.
-        const createdIssue = await createIssueOnGithub(options, Contributors)
+        const createdIssue = await createIssueOnGithub(options, contributors)
         // We are done here, we created a new issue.
         return new Result(
           `No Open/Closed issues were found for this rule - Created new Github Issue with issue number - ${createdIssue.data.number}`,
@@ -105,7 +105,7 @@ async function createGithubIssue(fs, options, targets, dryRun = false) {
           ) {
             try {
               // Issue should include the broken rule, a message in the body and a label.
-              await updateIssueOnGithub(options, issue.number, 0, Contributors)
+              await updateIssueOnGithub(options, issue.number, 0, contributors)
             } catch (e) {
               return new Result(
                 `Something went wrong when trying to update issue id: ${issue.number}: ${e.message}`,
@@ -140,7 +140,7 @@ async function createGithubIssue(fs, options, targets, dryRun = false) {
         } else {
           try {
             // Issue should include the broken rule, a message in the body and a label.
-            await updateIssueOnGithub(options, issue.number, 0, Contributors)
+            await updateIssueOnGithub(options, issue.number, 0, contributors)
           } catch (e) {
             return new Result(
               `Something went wrong when trying to update issue id: ${issue.number}: ${e.message}`,
@@ -165,7 +165,7 @@ async function createGithubIssue(fs, options, targets, dryRun = false) {
     // Issue should include the broken rule, a message in the body and a label.
     try {
       // Issue should include the broken rule, a message in the body and a label.
-      const newIssue = await createIssueOnGithub(options, Contributors)
+      const newIssue = await createIssueOnGithub(options, contributors)
       // We are done here, we created a new issue.
       return new Result(
         `Github Issue ${newIssue.data.number} Created!`,

--- a/fixes/github-issue-create.js
+++ b/fixes/github-issue-create.js
@@ -53,10 +53,7 @@ async function createGithubIssue(fs, options, targets, dryRun = false) {
       options.assignTopCommitter = true
     }
     if (options.assignTopCommitter) {
-      contributors = await getTopCommittersOfRepository(
-        targetOrg,
-        targetRepository
-      )
+      contributors = await getTopContributors(targetOrg, targetRepository)
       if (contributors !== undefined && contributors.data.length > 0) {
         issueAssignees.push(contributors.data[0].login)
       }
@@ -191,7 +188,7 @@ async function createGithubIssue(fs, options, targets, dryRun = false) {
  * @param {object} targetRepository Target Repository
  * @returns {object} Returns array of contributors.
  */
-async function getTopCommittersOfRepository(targetOrg, targetRepository) {
+async function getTopContributors(targetOrg, targetRepository) {
   try {
     return await this.Octokit.request(
       'GET /repos/{owner}/{repo}/contributors',

--- a/fixes/github-issue-create.js
+++ b/fixes/github-issue-create.js
@@ -105,7 +105,7 @@ async function createGithubIssue(fs, options, targets, dryRun = false) {
           ) {
             try {
               // Issue should include the broken rule, a message in the body and a label.
-              await updateIssueOnGithub(options, issue.number, 0, contributors)
+              await updateIssueOnGithub(options, issue.number, contributors)
             } catch (e) {
               return new Result(
                 `Something went wrong when trying to update issue id: ${issue.number}: ${e.message}`,
@@ -140,7 +140,7 @@ async function createGithubIssue(fs, options, targets, dryRun = false) {
         } else {
           try {
             // Issue should include the broken rule, a message in the body and a label.
-            await updateIssueOnGithub(options, issue.number, 0, contributors)
+            await updateIssueOnGithub(options, issue.number, contributors)
           } catch (e) {
             return new Result(
               `Something went wrong when trying to update issue id: ${issue.number}: ${e.message}`,
@@ -254,15 +254,15 @@ async function createIssueOnGithub(
  *
  * @param {object} options The rule configuration.
  * @param {string} issueNumber The number of the issue we should update.
- * @param {number} assigneeSelectCount counter for which assignee was selected
  * @param {array<object>} assignees array of contributors
+ * @param {number} assigneeSelectIndex index for which assignee was selected
  * @returns {object} Returns issue after updating it via the Github API.
  */
 async function updateIssueOnGithub(
   options,
   issueNumber,
-  assigneeSelectCount,
-  assignees
+  assignees,
+  assigneeSelectIndex = 0
 ) {
   // This might not be needed
   const issueBodyWithId = options.issueBody.concat(
@@ -288,17 +288,17 @@ async function updateIssueOnGithub(
     ) {
       issueAssignees = []
       if (
-        assigneeSelectCount <= assignees.data.length &&
-        assigneeSelectCount <= maxAssigneeRetryCount
+        assigneeSelectIndex <= assignees.data.length &&
+        assigneeSelectIndex <= maxAssigneeRetryCount
       ) {
-        assigneeSelectCount++
-        issueAssignees.push(assignees.data[assigneeSelectCount].login)
+        assigneeSelectIndex++
+        issueAssignees.push(assignees.data[assigneeSelectIndex].login)
       }
       return updateIssueOnGithub(
         options,
         issueNumber,
-        assigneeSelectCount,
-        assignees
+        assignees,
+        assigneeSelectIndex
       )
     } else {
       return Promise.reject(error)

--- a/fixes/helpers/github-issue-create-helpers.js
+++ b/fixes/helpers/github-issue-create-helpers.js
@@ -76,7 +76,7 @@ async function ensureAddedGithubLabels(
  * @param {string} targetOrg Organization/Owner of the repository.
  * @param {string} repo Name of the repository.
  * @param {string} label Label to check for.
- * @param {object} octoKit Instance of Octokit used to call Github API.
+ * @param {object} octoKit Instance of Octokit used to call GitHub API.
  * @returns {boolean} True if label is found, false otherwise.
  */
 async function doesLabelExistOnRepo(targetOrg, repo, label, octokit) {

--- a/tests/fixes/github_issue_create_tests.js
+++ b/tests/fixes/github_issue_create_tests.js
@@ -2,7 +2,6 @@ const { expect } = require('chai')
 const nock = require('nock')
 const { Octokit } = require('@octokit/rest')
 require('../../fixes/github-issue-create')
-require('../../fixes/github-issue-create')
 const Result = require('../../lib/result')
 function mockStandardGithubApiCalls(
   repoIssues,

--- a/tests/fixes/github_issue_create_tests.js
+++ b/tests/fixes/github_issue_create_tests.js
@@ -1,8 +1,12 @@
 const { expect } = require('chai')
 const nock = require('nock')
 const { Octokit } = require('@octokit/rest')
-
-function mockStandardGithubApiCalls(repoIssues, githubIssueTemplate) {
+require('../../fixes/github-issue-create')
+function mockStandardGithubApiCalls(
+  repoIssues,
+  githubIssueTemplate,
+  contributors
+) {
   nock('https://api.github.com')
     .get(
       `/repos/test/tester-repo/issues?labels=continuous-compliance%2Cautomated&state=all&sort=created&direction=desc`
@@ -20,7 +24,7 @@ function mockStandardGithubApiCalls(repoIssues, githubIssueTemplate) {
     .reply(200)
   nock('https://api.github.com')
     .get(`/repos/test/tester-repo/contributors`)
-    .reply(200)
+    .reply(200, contributors)
   nock('https://api.github.com')
     .post(`/repos/test/tester-repo/issues`)
     .reply(200, githubIssueTemplate)
@@ -35,6 +39,7 @@ describe('fixes', () => {
       issueCreator: 'Philips - Continuous Compliance',
       issueLabels: ['continuous-compliance', 'automated'],
       bypassLabel: 'CC: Bypass',
+      assignTopCommitter: false,
       issueTitle: 'Continuous Compliance - Valid test 👍',
       issueBody:
         'Hi there 👋, \n' +
@@ -364,6 +369,117 @@ describe('fixes', () => {
           expect(result.message).to.equal(
             'No Open/Closed issues were found for this rule - Created new Github Issue with issue number - 17'
           )
+        })
+        describe('without valid top contributor', () => {
+          it('it should not assign a person to the issue', async () => {
+            // Prepare
+            const contributors = [
+              {
+                login: 'test-user',
+                id: 1590451111337,
+                node_id: 'MDQ6VXNlcjE1OTA0NTQz',
+                avatar_url:
+                  'https://avatars.githubusercontent.com/u/1590451111337?v=4',
+                gravatar_id: '',
+                url: 'https://api.github.com/users/test-user',
+                html_url: 'https://github.com/test-user',
+                followers_url:
+                  'https://api.github.com/users/test-user/followers',
+                following_url:
+                  'https://api.github.com/users/test-user/following{/other_user}',
+                gists_url:
+                  'https://api.github.com/users/test-user/gists{/gist_id}',
+                starred_url:
+                  'https://api.github.com/users/test-user/starred{/owner}{/repo}',
+                subscriptions_url:
+                  'https://api.github.com/users/test-user/subscriptions',
+                organizations_url:
+                  'https://api.github.com/users/test-user/orgs',
+                repos_url: 'https://api.github.com/users/test-user/repos',
+                events_url:
+                  'https://api.github.com/users/test-user/events{/privacy}',
+                received_events_url:
+                  'https://api.github.com/users/test-user/received_events',
+                type: 'User',
+                site_admin: false,
+                contributions: 34
+              },
+              {
+                login: 'dependabot[bot]',
+                id: 49699333,
+                node_id: 'MDM6Qm90NDk2OTkzMzM=',
+                avatar_url:
+                  'https://avatars.githubusercontent.com/in/29110?v=4',
+                gravatar_id: '',
+                url: 'https://api.github.com/users/dependabot%5Bbot%5D',
+                html_url: 'https://github.com/apps/dependabot',
+                followers_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/followers',
+                following_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/following{/other_user}',
+                gists_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/gists{/gist_id}',
+                starred_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/starred{/owner}{/repo}',
+                subscriptions_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/subscriptions',
+                organizations_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/orgs',
+                repos_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/repos',
+                events_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/events{/privacy}',
+                received_events_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/received_events',
+                type: 'Bot',
+                site_admin: false,
+                contributions: 4
+              }
+            ]
+            nock('https://api.github.com')
+              .get(
+                `/repos/test/tester-repo/issues?labels=continuous-compliance%2Cautomated&state=all&sort=created&direction=desc`
+              )
+              .reply(200, [])
+            nock('https://api.github.com')
+              .get(`/repos/test/tester-repo/labels/continuous-compliance`)
+              .reply(200)
+            nock('https://api.github.com')
+              .get(`/repos/test/tester-repo/labels/automated`)
+              .reply(200)
+            nock('https://api.github.com')
+              .get(`/repos/test/tester-repo/labels/CC%3A%20Bypass`)
+              .reply(200)
+            nock('https://api.github.com')
+              .get(`/repos/test/tester-repo/contributors`)
+              .reply(200, contributors)
+            nock('https://api.github.com')
+              .post(`/repos/test/tester-repo/issues`)
+              .reply(422, {
+                status: 422,
+                message:
+                  'Validation Failed: {"value":"test-user","resource":"Issue","field":"assignees","code":"invalid"}'
+              })
+            nock('https://api.github.com')
+              .post(`/repos/test/tester-repo/issues`)
+              .reply(200, githubIssue)
+
+            const validOptionsWithContributionOption = validOptions
+            validOptionsWithContributionOption.assignTopCommitter = true
+
+            // Act
+            const result = await GithubIssueCreate(
+              null,
+              validOptionsWithContributionOption,
+              [],
+              true
+            )
+
+            // Assert
+            expect(result.message).to.equal(
+              'No Open/Closed issues were found for this rule - Created new Github Issue with issue number - 17'
+            )
+          })
         })
       })
     })

--- a/tests/fixes/github_issue_create_tests.js
+++ b/tests/fixes/github_issue_create_tests.js
@@ -2,6 +2,8 @@ const { expect } = require('chai')
 const nock = require('nock')
 const { Octokit } = require('@octokit/rest')
 require('../../fixes/github-issue-create')
+require('../../fixes/github-issue-create')
+const Result = require('../../lib/result')
 function mockStandardGithubApiCalls(
   repoIssues,
   githubIssueTemplate,
@@ -478,6 +480,104 @@ describe('fixes', () => {
             // Assert
             expect(result.message).to.equal(
               'No Open/Closed issues were found for this rule - Created new Github Issue with issue number - 17'
+            )
+          })
+        })
+        describe('when erroring', () => {
+          it('it should fail gracefully and fail the fix', async () => {
+            nock.cleanAll()
+            const contributors = [
+              {
+                login: 'test-user',
+                id: 1590451111337,
+                node_id: 'MDQ6VXNlcjE1OTA0NTQz',
+                avatar_url:
+                  'https://avatars.githubusercontent.com/u/1590451111337?v=4',
+                gravatar_id: '',
+                url: 'https://api.github.com/users/test-user',
+                html_url: 'https://github.com/test-user',
+                followers_url:
+                  'https://api.github.com/users/test-user/followers',
+                following_url:
+                  'https://api.github.com/users/test-user/following{/other_user}',
+                gists_url:
+                  'https://api.github.com/users/test-user/gists{/gist_id}',
+                starred_url:
+                  'https://api.github.com/users/test-user/starred{/owner}{/repo}',
+                subscriptions_url:
+                  'https://api.github.com/users/test-user/subscriptions',
+                organizations_url:
+                  'https://api.github.com/users/test-user/orgs',
+                repos_url: 'https://api.github.com/users/test-user/repos',
+                events_url:
+                  'https://api.github.com/users/test-user/events{/privacy}',
+                received_events_url:
+                  'https://api.github.com/users/test-user/received_events',
+                type: 'User',
+                site_admin: false,
+                contributions: 34
+              },
+              {
+                login: 'dependabot[bot]',
+                id: 49699333,
+                node_id: 'MDM6Qm90NDk2OTkzMzM=',
+                avatar_url:
+                  'https://avatars.githubusercontent.com/in/29110?v=4',
+                gravatar_id: '',
+                url: 'https://api.github.com/users/dependabot%5Bbot%5D',
+                html_url: 'https://github.com/apps/dependabot',
+                followers_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/followers',
+                following_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/following{/other_user}',
+                gists_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/gists{/gist_id}',
+                starred_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/starred{/owner}{/repo}',
+                subscriptions_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/subscriptions',
+                organizations_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/orgs',
+                repos_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/repos',
+                events_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/events{/privacy}',
+                received_events_url:
+                  'https://api.github.com/users/dependabot%5Bbot%5D/received_events',
+                type: 'Bot',
+                site_admin: false,
+                contributions: 4
+              }
+            ]
+            nock('https://api.github.com')
+              .get(
+                `/repos/test/tester-repo/issues?labels=continuous-compliance%2Cautomated&state=all&sort=created&direction=desc`
+              )
+              .reply(200, [])
+            nock('https://api.github.com')
+              .get(`/repos/test/tester-repo/labels/continuous-compliance`)
+              .reply(200)
+            nock('https://api.github.com')
+              .get(`/repos/test/tester-repo/labels/automated`)
+              .reply(200)
+            nock('https://api.github.com')
+              .get(`/repos/test/tester-repo/labels/CC%3A%20Bypass`)
+              .reply(200)
+            nock('https://api.github.com')
+              .get(`/repos/test/tester-repo/contributors`)
+              .reply(200, contributors)
+            nock('https://api.github.com')
+              .post(`/repos/test/tester-repo/issues`)
+              .reply(500, { message: 'service unavailable' })
+
+            // Act
+            const result = await GithubIssueCreate(null, validOptions, [], true)
+
+            // Assert
+            expect(result).to.be.an.instanceof(Result)
+            expect(result.passed).to.equal(false)
+            expect(result.message.trim()).to.equal(
+              'Something went wrong when trying to create the issue: service unavailable'
             )
           })
         })


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

## Motivation

Often some top contributors of organizations leave the organization, meaning they can no longer be assigned to issues or pull requests. This results in the create/update issue step failing completely.

## Proposed Changes

When a 422 error is caught, check the message and check if it's related to assignee field. If it is, retry a maximum of 6 times. After 6 times, we do not assign anyone.


I want to refactor this fix completely, as it's quite difficult to maintain. Will do this in an upcoming PR.

Signed-off-by: Brend Smits <brend.smits@philips.com>