### PR TITLE
add integration test to verify functionality of branches option feature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,6 +51,7 @@ declare class RuleInfo {
   fixConfig?: any
   policyInfo?: string
   policyUrl?: string
+  disableAsync?: boolean
 }
 
 declare class FormatResult {

--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,7 @@ declare class RuleInfo {
   fixConfig?: any
   policyInfo?: string
   policyUrl?: string
-  disableAsync?: boolean
+  sequentialOnly?: boolean
 }
 
 declare class FormatResult {

--- a/index.js
+++ b/index.js
@@ -370,7 +370,9 @@ async function runRuleset(ruleset, targets, fileSystem, dryRun) {
   // generate a flat array of axiom string identifiers
   /** @ignore @type {string[]} */
   let targetArray = []
-  const sequentialRuleProcessingArrayList = ruleset.filter(r => r.disableAsync)
+  const sequentialRuleProcessingArrayList = ruleset.filter(
+    r => r.sequentialOnly
+  )
   if (typeof targets !== 'boolean') {
     targetArray = Object.entries(targets)
       // restricted to only passed axioms
@@ -388,19 +390,13 @@ async function runRuleset(ruleset, targets, fileSystem, dryRun) {
   // load the fixes
   const allFixes = await loadFixes()
   // run the ruleset async
-  ruleset = ruleset.filter(r => !r.disableAsync)
+  ruleset = ruleset.filter(r => !r.sequentialOnly)
   const results = ruleset.map(async r => {
     // check axioms and enable appropriately
     if (r.level === 'off') {
       return Promise.resolve(
         FormatResult.CreateIgnored(r, 'ignored because level is "off"')
       )
-    }
-    // check if rule should be processes sequentially
-    if (r.disableAsync) {
-      console.log(`Found rule that disabled async! ${r.name}`)
-      sequentialRuleProcessingArrayList.push(r)
-      return
     }
     // filter to only targets with no matches
     if (typeof targets !== 'boolean' && r.where && r.where.length) {

--- a/index.js
+++ b/index.js
@@ -370,7 +370,7 @@ async function runRuleset(ruleset, targets, fileSystem, dryRun) {
   // generate a flat array of axiom string identifiers
   /** @ignore @type {string[]} */
   let targetArray = []
-  const sequentialRuleProcessingArrayList = []
+  const sequentialRuleProcessingArrayList = ruleset.filter(r => r.disableAsync)
   if (typeof targets !== 'boolean') {
     targetArray = Object.entries(targets)
       // restricted to only passed axioms
@@ -388,6 +388,7 @@ async function runRuleset(ruleset, targets, fileSystem, dryRun) {
   // load the fixes
   const allFixes = await loadFixes()
   // run the ruleset async
+  ruleset = ruleset.filter(r => !r.disableAsync)
   const results = ruleset.map(async r => {
     // check axioms and enable appropriately
     if (r.level === 'off') {

--- a/lib/config.js
+++ b/lib/config.js
@@ -184,6 +184,7 @@ function parseConfig(config) {
         new RuleInfo(
           name,
           cfg.level,
+          cfg.disableAsync,
           cfg.where,
           cfg.rule.type,
           cfg.rule.options,

--- a/lib/config.js
+++ b/lib/config.js
@@ -184,14 +184,14 @@ function parseConfig(config) {
         new RuleInfo(
           name,
           cfg.level,
-          cfg.disableAsync,
           cfg.where,
           cfg.rule.type,
           cfg.rule.options,
           cfg.fix && cfg.fix.type,
           cfg.fix && cfg.fix.options,
           cfg.policyInfo,
-          cfg.policyUrl
+          cfg.policyUrl,
+          cfg.disableAsync
         )
     )
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -191,7 +191,7 @@ function parseConfig(config) {
           cfg.fix && cfg.fix.options,
           cfg.policyInfo,
           cfg.policyUrl,
-          cfg.disableAsync
+          cfg.sequentialOnly
         )
     )
   }

--- a/lib/ruleinfo.js
+++ b/lib/ruleinfo.js
@@ -27,7 +27,7 @@ class RuleInfo {
     fixConfig,
     policyInfo,
     policyUrl,
-    disableAsync
+    sequentialOnly
   ) {
     this.name = name
     this.level = level
@@ -38,7 +38,7 @@ class RuleInfo {
     if (fixConfig) this.fixConfig = fixConfig
     if (policyInfo) this.policyInfo = policyInfo
     if (policyUrl) this.policyUrl = policyUrl
-    if (disableAsync) this.disableAsync = disableAsync
+    if (sequentialOnly) this.sequentialOnly = sequentialOnly
   }
 }
 

--- a/lib/ruleinfo.js
+++ b/lib/ruleinfo.js
@@ -20,6 +20,7 @@ class RuleInfo {
   constructor(
     name,
     level,
+    disableAsync,
     where,
     ruleType,
     ruleConfig,
@@ -37,6 +38,7 @@ class RuleInfo {
     if (fixConfig) this.fixConfig = fixConfig
     if (policyInfo) this.policyInfo = policyInfo
     if (policyUrl) this.policyUrl = policyUrl
+    if (disableAsync) this.disableAsync = disableAsync
   }
 }
 

--- a/lib/ruleinfo.js
+++ b/lib/ruleinfo.js
@@ -20,14 +20,14 @@ class RuleInfo {
   constructor(
     name,
     level,
-    disableAsync,
     where,
     ruleType,
     ruleConfig,
     fixType,
     fixConfig,
     policyInfo,
-    policyUrl
+    policyUrl,
+    disableAsync
   ) {
     this.name = name
     this.level = level

--- a/rules/any-file-contents-config.json
+++ b/rules/any-file-contents-config.json
@@ -14,7 +14,7 @@
     "branches": {
       "type": "array",
       "items": { "type": "string" },
-      "default": ["default"]
+      "default": []
     },
     "content": { "type": "string" },
     "flags": { "type": "string" },

--- a/rules/file-contents-config.json
+++ b/rules/file-contents-config.json
@@ -14,7 +14,7 @@
     "branches": {
       "type": "array",
       "items": { "type": "string" },
-      "default": ["default"]
+      "default": []
     },
     "content": { "type": "string" },
     "flags": { "type": "string" },

--- a/rules/file-contents.js
+++ b/rules/file-contents.js
@@ -74,7 +74,7 @@ async function fileContents(fs, options, not = false, any = false, git) {
         const passed = fileContents.search(regexp) >= 0
         const message = `${
           passed ? 'Contains' : "Doesn't contain"
-        } ${getContent(options)}`
+        } ${getContent(options)} + branch: ${branch}`
 
         return {
           passed: not ? !passed : passed,

--- a/rules/file-contents.js
+++ b/rules/file-contents.js
@@ -74,7 +74,7 @@ async function fileContents(fs, options, not = false, any = false, git) {
         const passed = fileContents.search(regexp) >= 0
         const message = `${
           passed ? 'Contains' : "Doesn't contain"
-        } ${getContent(options)} + branch: ${branch}`
+        } ${getContent(options)}`
 
         return {
           passed: not ? !passed : passed,

--- a/rules/file-not-contents-config.json
+++ b/rules/file-not-contents-config.json
@@ -14,7 +14,7 @@
     "branches": {
       "type": "array",
       "items": { "type": "string" },
-      "default": ["default"]
+      "default": []
     },
     "content": { "type": "string" },
     "flags": { "type": "string" },

--- a/rulesets/schema.json
+++ b/rulesets/schema.json
@@ -42,7 +42,7 @@
           "additionalProperties": false,
           "properties": {
             "level": { "enum": ["off", "warning", "error"] },
-            "disableAsync": {
+            "sequentialOnly": {
               "type": "boolean",
               "default": false
             },

--- a/rulesets/schema.json
+++ b/rulesets/schema.json
@@ -42,6 +42,10 @@
           "additionalProperties": false,
           "properties": {
             "level": { "enum": ["off", "warning", "error"] },
+            "disableAsync": {
+              "type": "boolean",
+              "default": false
+            },
             "where": {
               "type": "array",
               "items": { "type": "string" }

--- a/tests/rules/file_contents_tests.js
+++ b/tests/rules/file_contents_tests.js
@@ -4,10 +4,33 @@
 const chai = require('chai')
 const expect = chai.expect
 const FileSystem = require('../../lib/file_system')
+const cp = require('child_process')
+const path = require('path')
+
+/**
+ * Execute a command in a childprocess asynchronously. Not secure, but good for testing.
+ *
+ * @param {string} command The command to execute
+ * @param {import('child_process').ExecOptions} [opts] Options to execute against.
+ * @returns {Promise<{out: string, err: string, code: number}>} The command output
+ */
+async function execAsync(command, opts = {}) {
+  return new Promise((resolve, reject) => {
+    cp.exec(command, opts, (err, outstd, errstd) =>
+      err !== null && err.code === undefined
+        ? reject(err)
+        : resolve({
+            out: outstd,
+            err: errstd,
+            code: err !== null ? err.code : 0
+          })
+    )
+  })
+}
 
 describe('rule', () => {
+  const fileContents = require('../../rules/file-contents')
   describe('files_contents', () => {
-    const fileContents = require('../../rules/file-contents')
     const mockGit = {
       branchLocal() {
         return { current: 'master' }
@@ -196,6 +219,27 @@ describe('rule', () => {
       const actual = await fileContents(fs, rule, undefined, undefined, mockGit)
 
       expect(actual.passed).to.equal(true)
+    })
+  })
+  describe('rule file_contents in branch', function () {
+    const repolinterPath =
+      process.platform === 'win32'
+        ? path.resolve('bin/repolinter.bat')
+        : path.resolve('bin/repolinter.js')
+    this.timeout(30000)
+    describe('when checking only default branch', () => {
+      it('returns should not find content from different branches', async () => {})
+    })
+    describe('when checking various branches', () => {
+      it('returns content from both default and target branch', async () => {
+        const actual = await execAsync(
+          `${repolinterPath} lint -g https://github.com/Brend-Smits/repolinter-tests.git --rulesetFile rulesets/any-content-check-branch.json`
+        )
+
+        expect(actual.code).to.equal(0)
+        expect(actual.out.trim()).to.contain('Lint:')
+      })
+      it('returns matched content from different branch that is not default', async () => {})
     })
   })
 })

--- a/tests/rules/file_contents_tests.js
+++ b/tests/rules/file_contents_tests.js
@@ -228,7 +228,22 @@ describe('rule', () => {
         : path.resolve('bin/repolinter.js')
     this.timeout(30000)
     describe('when checking only default branch', () => {
-      it('returns should not find content from different branches', async () => {})
+      it('returned content should not find content from different branches', async () => {
+        const actual = await execAsync(
+          `${repolinterPath} lint -g https://github.com/Brend-Smits/repolinter-tests.git --rulesetFile rulesets/file-content-default-branch.json`
+        )
+
+        expect(actual.code).to.equal(0)
+        expect(actual.out.trim()).to.contain('Lint:')
+      })
+      it('returns error if content is not found', async () => {
+        const actual = await execAsync(
+          `${repolinterPath} lint -g https://github.com/Brend-Smits/repolinter-tests.git --rulesetFile rulesets/file-content-default-branch-should-not-find.json`
+        )
+
+        expect(actual.code).to.equal(1)
+        expect(actual.out.trim()).to.contain('Lint:')
+      })
     })
     describe('when checking various branches', () => {
       it('returns content from both default and target branch', async () => {
@@ -239,7 +254,14 @@ describe('rule', () => {
         expect(actual.code).to.equal(0)
         expect(actual.out.trim()).to.contain('Lint:')
       })
-      it('returns matched content from different branch that is not default', async () => {})
+      it('returns matched content from different branch that is not default', async () => {
+        const actual = await execAsync(
+          `${repolinterPath} lint -g https://github.com/Brend-Smits/repolinter-tests.git --rulesetFile rulesets/any-content-check-only-target-branch.json`
+        )
+
+        expect(actual.code).to.equal(0)
+        expect(actual.out.trim()).to.contain('Lint:')
+      })
     })
   })
 })


### PR DESCRIPTION
Signed-off-by: Brend Smits <brend.smits@philips.com>

## Motivation

A lack of integration tests will prevent safe refactoring in the future. Also, some tests can not be executed async.

## Proposed Changes

Add an option to configure this per rule via ``sequentialOnly`` option. This option is set to false by default.