### PR TITLE
feat: add DoNotReopen parameter to github-issue-create fix

### DIFF
--- a/fixes/github-issue-create-config.json
+++ b/fixes/github-issue-create-config.json
@@ -14,7 +14,7 @@
       "type": "string",
       "description": "Comment to add when reopening issues."
     },
-    "DoNotReopen": {
+    "doNotReopen": {
       "type": "boolean",
       "default": false,
       "description": "When set to true, closed issues will not be reopened or commented on. When false, normal reopening behavior applies."

--- a/fixes/github-issue-create-config.json
+++ b/fixes/github-issue-create-config.json
@@ -11,7 +11,13 @@
       "type": "string"
     },
     "commentBody": {
-      "type": "string"
+      "type": "string",
+      "description": "Comment to add when reopening issues."
+    },
+    "DoNotReopen": {
+      "type": "boolean",
+      "default": false,
+      "description": "When set to true, closed issues will not be reopened or commented on. When false, normal reopening behavior applies."
     },
     "issueTitle": {
       "type": "string"

--- a/fixes/github-issue-create.js
+++ b/fixes/github-issue-create.js
@@ -135,9 +135,22 @@ async function createGithubIssue(fs, options, targets, dryRun = false) {
             true
           )
         } else {
+          if (options.DoNotReopen === true) {
+            return new Result(
+              `DoNotReopen rule processed - no action taken on closed Github Issue ${issue.number} (DoNotReopen=true)`,
+              [],
+              true
+            )
+          }
+
           try {
-            // Issue should include the broken rule, a message in the body and a label.
             await updateIssueOnGithub(options, issue.number, contributors)
+            await commentOnGithubIssue(options, issue.number)
+            return new Result(
+              `Github Issue ${issue.number} re-opened as there seems to be regression!`,
+              [],
+              true
+            )
           } catch (e) {
             return new Result(
               `Something went wrong when trying to update issue id: ${issue.number}: ${e.message}`,
@@ -145,12 +158,6 @@ async function createGithubIssue(fs, options, targets, dryRun = false) {
               false
             )
           }
-          await commentOnGithubIssue(options, issue.number)
-          return new Result(
-            `Github Issue ${issue.number} re-opened as there seems to be regression!`,
-            [],
-            true
-          )
         }
       } else {
         console.log(

--- a/fixes/github-issue-create.js
+++ b/fixes/github-issue-create.js
@@ -135,9 +135,9 @@ async function createGithubIssue(fs, options, targets, dryRun = false) {
             true
           )
         } else {
-          if (options.DoNotReopen === true) {
+          if (options.doNotReopen === true) {
             return new Result(
-              `DoNotReopen rule processed - no action taken on closed Github Issue ${issue.number} (DoNotReopen=true)`,
+              `doNotReopen rule processed - no action taken on closed Github Issue ${issue.number} (doNotReopen=true)`,
               [],
               true
             )

--- a/tests/fixes/github_issue_create_tests.js
+++ b/tests/fixes/github_issue_create_tests.js
@@ -582,5 +582,123 @@ describe('fixes', () => {
         })
       })
     })
+
+    describe('DoNotReopen functionality', () => {
+      afterEach(() => {
+        nock.cleanAll()
+      })
+
+      describe('when DoNotReopen is true', () => {
+        it('should not reopen or comment on closed issues', async () => {
+          const closedIssue = [
+            {
+              number: 123,
+              state: 'closed',
+              title: 'Test Issue',
+              body: 'Test body\n Unique rule set ID: test-rule-123',
+              labels: [{ name: 'continuous-compliance' }]
+            }
+          ]
+
+          const doNotReopenOptions = {
+            ...validOptions,
+            DoNotReopen: true,
+            uniqueRuleId: 'test-rule-123'
+          }
+
+          nock('https://api.github.com')
+            .get(
+              `/repos/test/tester-repo/issues?labels=continuous-compliance%2Cautomated&state=all&sort=created&direction=desc`
+            )
+            .reply(200, closedIssue)
+
+          // Mock label existence checks
+          nock('https://api.github.com')
+            .get(`/repos/test/tester-repo/labels/continuous-compliance`)
+            .reply(200)
+          nock('https://api.github.com')
+            .get(`/repos/test/tester-repo/labels/automated`)
+            .reply(200)
+          nock('https://api.github.com')
+            .get(`/repos/test/tester-repo/labels/CC%3A%20Bypass`)
+            .reply(200)
+
+          // Mock contributors call that happens before DoNotReopen check
+          nock('https://api.github.com')
+            .get(`/repos/test/tester-repo/contributors`)
+            .reply(200, [])
+
+          const result = await GithubIssueCreate(
+            null,
+            doNotReopenOptions,
+            [],
+            true
+          )
+
+          expect(result).to.be.an.instanceof(Result)
+          expect(result.passed).to.equal(true)
+          expect(result.message).to.include(
+            'DoNotReopen rule processed - no action taken on closed Github Issue 123 (DoNotReopen=true)'
+          )
+        })
+      })
+
+      describe('when DoNotReopen is false or undefined', () => {
+        it('should reopen and comment on closed issues', async () => {
+          const closedIssue = [
+            {
+              number: 456,
+              state: 'closed',
+              title: 'Test Issue',
+              body: 'Test body\n Unique rule set ID: test-rule-456',
+              labels: [{ name: 'continuous-compliance' }]
+            }
+          ]
+
+          const normalOptions = {
+            ...validOptions,
+            DoNotReopen: false,
+            uniqueRuleId: 'test-rule-456'
+          }
+
+          nock('https://api.github.com')
+            .get(
+              `/repos/test/tester-repo/issues?labels=continuous-compliance%2Cautomated&state=all&sort=created&direction=desc`
+            )
+            .reply(200, closedIssue)
+
+          // Mock label existence checks (multiple calls allowed)
+          nock('https://api.github.com')
+            .persist()
+            .get(`/repos/test/tester-repo/labels/continuous-compliance`)
+            .reply(200)
+          nock('https://api.github.com')
+            .persist()
+            .get(`/repos/test/tester-repo/labels/automated`)
+            .reply(200)
+          nock('https://api.github.com')
+            .persist()
+            .get(`/repos/test/tester-repo/labels/CC%3A%20Bypass`)
+            .reply(200)
+          nock('https://api.github.com')
+            .get(`/repos/test/tester-repo/contributors`)
+            .reply(200, [])
+          nock('https://api.github.com')
+            .patch(`/repos/test/tester-repo/issues/456`)
+            .reply(200, { number: 456, state: 'open' })
+          nock('https://api.github.com')
+            .post(`/repos/test/tester-repo/issues/456/comments`)
+            .reply(200, { id: 1, body: normalOptions.commentBody })
+
+          const result = await GithubIssueCreate(null, normalOptions, [], true)
+
+          expect(result).to.be.an.instanceof(Result)
+          expect(result.passed).to.equal(true)
+          expect(result.message).to.include(
+            'Github Issue 456 re-opened as there seems to be regression!'
+          )
+        })
+      })
+    })
   })
 })

--- a/tests/fixes/github_issue_create_tests.js
+++ b/tests/fixes/github_issue_create_tests.js
@@ -583,12 +583,12 @@ describe('fixes', () => {
       })
     })
 
-    describe('DoNotReopen functionality', () => {
+    describe('doNotReopen functionality', () => {
       afterEach(() => {
         nock.cleanAll()
       })
 
-      describe('when DoNotReopen is true', () => {
+      describe('when doNotReopen is true', () => {
         it('should not reopen or comment on closed issues', async () => {
           const closedIssue = [
             {
@@ -602,7 +602,7 @@ describe('fixes', () => {
 
           const doNotReopenOptions = {
             ...validOptions,
-            DoNotReopen: true,
+            doNotReopen: true,
             uniqueRuleId: 'test-rule-123'
           }
 
@@ -623,7 +623,7 @@ describe('fixes', () => {
             .get(`/repos/test/tester-repo/labels/CC%3A%20Bypass`)
             .reply(200)
 
-          // Mock contributors call that happens before DoNotReopen check
+          // Mock contributors call that happens before doNotReopen check
           nock('https://api.github.com')
             .get(`/repos/test/tester-repo/contributors`)
             .reply(200, [])
@@ -638,12 +638,12 @@ describe('fixes', () => {
           expect(result).to.be.an.instanceof(Result)
           expect(result.passed).to.equal(true)
           expect(result.message).to.include(
-            'DoNotReopen rule processed - no action taken on closed Github Issue 123 (DoNotReopen=true)'
+            'doNotReopen rule processed - no action taken on closed Github Issue 123 (doNotReopen=true)'
           )
         })
       })
 
-      describe('when DoNotReopen is false or undefined', () => {
+      describe('when doNotReopen is false or undefined', () => {
         it('should reopen and comment on closed issues', async () => {
           const closedIssue = [
             {
@@ -657,7 +657,7 @@ describe('fixes', () => {
 
           const normalOptions = {
             ...validOptions,
-            DoNotReopen: false,
+            doNotReopen: false,
             uniqueRuleId: 'test-rule-456'
           }
 


### PR DESCRIPTION
This pull request adds a new configuration option to control whether closed GitHub issues should be reopened or commented on, and updates the implementation and tests to support this behavior.

Applicable to compliance issues concerning education and awareness.
* Educational/Informational - Provide guidance rather than enforce requirements
* Best Practice Suggestions - Recommend improvements but not mandatory

 The main changes are grouped below:

**Configuration changes:**

* Added a new boolean option `DoNotReopen` to `fixes/github-issue-create-config.json`, which prevents closed issues from being reopened or commented on when set to `true`. This option is documented in the config file.

**Behavioral changes in issue handling:**

* Updated the logic in `fixes/github-issue-create.js` so that if `DoNotReopen` is `true`, the function skips reopening or commenting on closed issues and returns a specific result message. If `DoNotReopen` is `false` or unset, the normal behavior applies.

**Test coverage improvements:**

* Added a new test suite in `tests/fixes/github_issue_create_tests.js` to verify the new `DoNotReopen` functionality, including cases where the option is `true` (no action on closed issues) and `false` or undefined (issues are reopened and commented on).